### PR TITLE
Http to https redirect 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -136,8 +136,8 @@ resource "azurerm_application_gateway" "ag" {
 
   dynamic "http_listener" {
     for_each = [for app in local.gateways[count.index].app_configuration : {
-      name             = "${app.product}-${app.component}-redirect"
-      host_name        = join(".", [lookup(app, "host_name_prefix", "${app.product}-${app.component}-${var.env}"), "${local.gateways[count.index].gateway_configuration.host_name_suffix}"])
+      name      = "${app.product}-${app.component}-redirect"
+      host_name = join(".", [lookup(app, "host_name_prefix", "${app.product}-${app.component}-${var.env}"), "${local.gateways[count.index].gateway_configuration.host_name_suffix}"])
       }
       if lookup(app, "http_to_https_redirect", false) == true
     ]
@@ -153,8 +153,8 @@ resource "azurerm_application_gateway" "ag" {
 
   dynamic "redirect_configuration" {
     for_each = [for app in local.gateways[count.index].app_configuration : {
-      name             = "${app.product}-${app.component}-redirect"
-      target_name      = "${app.product}-${app.component}"
+      name        = "${app.product}-${app.component}-redirect"
+      target_name = "${app.product}-${app.component}"
       }
       if lookup(app, "http_to_https_redirect", false) == true
     ]
@@ -184,7 +184,7 @@ resource "azurerm_application_gateway" "ag" {
 
   dynamic "request_routing_rule" {
     for_each = [for app in local.gateways[count.index].app_configuration : {
-      name             = "${app.product}-${app.component}-redirect"
+      name = "${app.product}-${app.component}-redirect"
       }
       if lookup(app, "http_to_https_redirect", false) == true
     ]

--- a/main.tf
+++ b/main.tf
@@ -134,6 +134,40 @@ resource "azurerm_application_gateway" "ag" {
     }
   }
 
+  dynamic "http_listener" {
+    for_each = [for app in local.gateways[count.index].app_configuration : {
+      name             = "${app.product}-${app.component}-redirect"
+      host_name        = join(".", [lookup(app, "host_name_prefix", "${app.product}-${app.component}-${var.env}"), "${local.gateways[count.index].gateway_configuration.host_name_suffix}"])
+      }
+      if lookup(app, "http_to_https_redirect", false) == true
+    ]
+
+    content {
+      name                           = http_listener.value.name
+      frontend_ip_configuration_name = "appGwPrivateFrontendIp"
+      frontend_port_name             = "http"
+      protocol                       = "Http"
+      host_name                      = http_listener.value.host_name
+    }
+  }
+
+  dynamic "redirect_configuration" {
+    for_each = [for app in local.gateways[count.index].app_configuration : {
+      name             = "${app.product}-${app.component}-redirect"
+      target_name      = "${app.product}-${app.component}"
+      }
+      if lookup(app, "http_to_https_redirect", false) == true
+    ]
+
+    content {
+      name                 = redirect_configuration.value.name
+      redirect_type        = "Permanent"
+      include_path         = true
+      include_query_string = true
+      target_listener_name = redirect_configuration.value.target_name
+    }
+  }
+
   dynamic "request_routing_rule" {
     for_each = [for app in local.gateways[count.index].app_configuration : {
       name = "${app.product}-${app.component}"
@@ -145,6 +179,21 @@ resource "azurerm_application_gateway" "ag" {
       http_listener_name         = request_routing_rule.value.name
       backend_address_pool_name  = request_routing_rule.value.name
       backend_http_settings_name = request_routing_rule.value.name
+    }
+  }
+
+  dynamic "request_routing_rule" {
+    for_each = [for app in local.gateways[count.index].app_configuration : {
+      name             = "${app.product}-${app.component}-redirect"
+      }
+      if lookup(app, "http_to_https_redirect", false) == true
+    ]
+
+    content {
+      name                        = request_routing_rule.value.name
+      rule_type                   = "Basic"
+      http_listener_name          = request_routing_rule.value.name
+      redirect_configuration_name = request_routing_rule.value.name
     }
   }
 }


### PR DESCRIPTION
Using a  http_to_https_redirect flag, so will only apply where http_to_https_redirect has been set to true.
This was needed as on the docmosis UI, after login it would bring the user to http and a 404.

Branch tested from azure-platform-terraform https://github.com/hmcts/azure-platform-terraform/pull/701/files
https://dev.azure.com/hmcts/CNP/_build/results?buildId=125621&view=results

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
