### PR TITLE
fix host name for docmosis redirect

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -137,7 +137,7 @@ resource "azurerm_application_gateway" "ag" {
   dynamic "http_listener" {
     for_each = [for app in local.gateways[count.index].app_configuration : {
       name      = "${app.product}-${app.component}-redirect"
-      host_name = join(".", [lookup(app, "host_name_prefix", "${app.product}-${app.component}-${var.env}"), "${local.gateways[count.index].gateway_configuration.host_name_suffix}"])
+      host_name = join(".", [lookup(app, "host_name_prefix", "${app.product}-${app.component}"), local.gateways[count.index].gateway_configuration.ssl_host_name_suffix])
       }
       if lookup(app, "http_to_https_redirect", false) == true
     ]


### PR DESCRIPTION
Test from azure-platform-terraform on sandbox
https://dev.azure.com/hmcts/CNP/_build/results?buildId=126864&view=logs&j=21a368f7-8e00-5e5f-2d29-ad43b7af2aab&t=0fc228ba-becc-5a78-1c0f-b8b027e0f895

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
