### PR TITLE
DTSPO-3182 Auto update ssl certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
+tfplan
 
 # Include override files you do wish to add to version control using negated pattern
 #

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -1,0 +1,12 @@
+gateways:
+  - gateway_configuration:
+      host_name_suffix: service.core-compute-sandbox.internal
+      ssl_host_name_suffix: sandbox.platform.hmcts.net
+      certificate_name: wildcard-sandbox-platform-hmcts-net
+      private_ip_address: 10.2.13.122
+    app_configuration:
+      - product: draft-store
+        component: service
+        ssl_enabled: true
+      - product: draft-store2
+        component: service

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,19 @@
+provider "azurerm" {
+  features {}
+}
+
+module "app-gw" {
+  source = "../"
+
+  yaml_path                  = "${path.cwd}/config.yaml"
+  env                        = "local"
+  location                   = "uksouth"
+  private_ip_address         = ["10.10.7.112"]
+  backend_pool_ip_addresses  = ["10.100.1.1"]
+  vault_name                 = "acmedcdcftappssbox"
+  vnet_rg                    = "aks-infra-sbox-rg"
+  vnet_name                  = "core-sbox-vnet"
+  common_tags                = {}
+  log_analytics_workspace_id = "/subscriptions/bf308a5c-0624-4334-8ff8-8dca9fd43783/resourceGroups/oms-automation/providers/Microsoft.OperationalInsights/workspaces/hmcts-sandbox"
+  key_vault_resource_group   = "cft-platform-sbox-rg"
+}

--- a/identity.tf
+++ b/identity.tf
@@ -1,0 +1,14 @@
+resource "azurerm_user_assigned_identity" "identity" {
+  name = "aks-${var.env}-agw"
+  resource_group_name = var.vnet_rg
+  location = var.location
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_role_assignment" "identity" {
+  principal_id = azurerm_user_assigned_identity.identity.principal_id
+  scope = data.azurerm_key_vault.main.id
+
+  role_definition_name = "Key Vault Secrets User"
+}

--- a/identity.tf
+++ b/identity.tf
@@ -1,14 +1,14 @@
 resource "azurerm_user_assigned_identity" "identity" {
-  name = "aks-${var.env}-agw"
+  name                = "aks-${var.env}-agw"
   resource_group_name = var.vnet_rg
-  location = var.location
+  location            = var.location
 }
 
 data "azurerm_client_config" "current" {}
 
 resource "azurerm_role_assignment" "identity" {
   principal_id = azurerm_user_assigned_identity.identity.principal_id
-  scope = data.azurerm_key_vault.main.id
+  scope        = data.azurerm_key_vault.main.id
 
   role_definition_name = "Key Vault Secrets User"
 }

--- a/main.tf
+++ b/main.tf
@@ -92,10 +92,13 @@ resource "azurerm_application_gateway" "ag" {
     }
   }
 
+  identity {
+    identity_ids = [azurerm_user_assigned_identity.identity.id]
+  }
+
   ssl_certificate {
     name     = local.gateways[count.index].gateway_configuration.certificate_name
-    data     = data.azurerm_key_vault_secret.certificate[count.index].value
-    password = ""
+    key_vault_secret_id     = data.azurerm_key_vault_secret.certificate[count.index].versionless_id
   }
 
   dynamic "http_listener" {
@@ -181,6 +184,8 @@ resource "azurerm_application_gateway" "ag" {
       redirect_configuration_name = request_routing_rule.value.name
     }
   }
+
+  depends_on = [azurerm_role_assignment.identity]
 }
 
 data "azurerm_monitor_diagnostic_categories" "diagnostic_categories" {

--- a/main.tf
+++ b/main.tf
@@ -97,8 +97,8 @@ resource "azurerm_application_gateway" "ag" {
   }
 
   ssl_certificate {
-    name     = local.gateways[count.index].gateway_configuration.certificate_name
-    key_vault_secret_id     = data.azurerm_key_vault_secret.certificate[count.index].versionless_id
+    name                = local.gateways[count.index].gateway_configuration.certificate_name
+    key_vault_secret_id = data.azurerm_key_vault_secret.certificate[count.index].versionless_id
   }
 
   dynamic "http_listener" {

--- a/secret.tf
+++ b/secret.tf
@@ -1,9 +1,0 @@
-
-resource "azurerm_key_vault_secret" "test" {
-  count        = length(var.private_ip_address)
-  name         = element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "internal-lb-ip" : "internal-lb-ip-${count.index}"
-  value        = element(var.private_ip_address, count.index)
-  key_vault_id = data.azurerm_key_vault.main.id
-
-  tags = var.common_tags
-}


### PR DESCRIPTION
Before merging the following needs to be done:


- [ ] Issue *.(.env.)?platform.hmcts.net certs in the corresponding key vaults via Let's encrypt
- [ ] Issue hmcts-access.service.gov.uk and courttribunalfinder.service.gov.uk certs in prod via Let's encrypt
- [ ] Switch existing config over to use the new key vaults in https://github.com/hmcts/azure-platform-terraform/ and https://github.com/hmcts/sharedservices-azure-platform/
- [ ] Remove providers that aren't required: https://github.com/hmcts/azure-platform-terraform/blob/master/components/cftapps_cluster_lb_backend/main.tf#L17-L20 
- [x] Verified that certs are actually updating, I've tested with a cert I issued, checked it's issue date and then issued a new one, it hasn't updated yet, Azure docs say this can take up to 4 hours:

Script:

```shell
$ date
Fri 28 May 2021 16:07:11 BST

$ curl -v -k -H "Host: draft-store-service.sandbox.platform.hmcts.net" https://10.10.7.112

* Server certificate:
*  subject: CN=*.sandbox.platform.hmcts.net
*  start date: May 28 13:15:50 2021 GMT
*  expire date: Aug 26 13:15:50 2021 GMT
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.

$ date
Tue  1 Jun 2021 12:03:26 BST

$ curl -v -k -H "Host: draft-store-service.sandbox.platform.hmcts.net" https://10.10.7.112
* Server certificate:
*  subject: CN=*.sandbox.platform.hmcts.net
*  start date: May 28 14:09:46 2021 GMT
*  expire date: Aug 26 14:09:46 2021 GMT
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify ok.

```