### PR TITLE
DTSPO-3187 - Allow creation of parallel resources with new names

### DIFF
--- a/identity.tf
+++ b/identity.tf
@@ -1,5 +1,5 @@
 resource "azurerm_user_assigned_identity" "identity" {
-  name                = (var.create_new_agw == true) ? "aks-${var.env}-appgw" : "aks-${var.env}-agw"
+  name                = (var.resource_prefix != null) ? "${var.resource_prefix}-aks-${var.env}-agw" : "aks-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
 

--- a/identity.tf
+++ b/identity.tf
@@ -1,5 +1,5 @@
 resource "azurerm_user_assigned_identity" "identity" {
-  name                = "aks-${var.env}-agw"
+  name                = (var.create_new_agw == true) ? "aks-${var.env}-appgw" : "aks-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
 

--- a/identity.tf
+++ b/identity.tf
@@ -1,5 +1,5 @@
 resource "azurerm_user_assigned_identity" "identity" {
-  name                = (var.resource_prefix != null) ? "${var.resource_prefix}-aks-${var.env}-agw" : "aks-${var.env}-agw"
+  name                = "${local.resource_prefix}aks-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
 

--- a/local.tf
+++ b/local.tf
@@ -1,3 +1,5 @@
 locals {
   gateways = yamldecode(data.local_file.configuration.content).gateways
+  pip_name = element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgw-${var.env}-pip" : "aks-appgw-${var.env}-pip-${count.index}"
+  new_pip_name = element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgateway-${var.env}-pip" : "aks-appgateway-${var.env}-pip-${count.index}"
 }

--- a/local.tf
+++ b/local.tf
@@ -1,5 +1,3 @@
 locals {
   gateways = yamldecode(data.local_file.configuration.content).gateways
-  pip_name = element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgw-${var.env}-pip" : "aks-appgw-${var.env}-pip-${count.index}"
-  new_pip_name = element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgateway-${var.env}-pip" : "aks-appgateway-${var.env}-pip-${count.index}"
 }

--- a/local.tf
+++ b/local.tf
@@ -1,3 +1,4 @@
 locals {
   gateways = yamldecode(data.local_file.configuration.content).gateways
+  resource_prefix = var.resource_prefix != null ? "${var.resource_prefix}-" : ""
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_application_gateway" "ag" {
-  name                = "aks${format("%02d", count.index)}-${var.env}-agw"
+  name                = (var.create_new_agw == true) ? "aks${format("%02d", count.index)}-backend-${var.env}-agw" : "aks${format("%02d", count.index)}-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
   tags                = var.common_tags

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_application_gateway" "ag" {
-  name                = (var.resource_prefix != null) ? "${var.resource_prefix}-aks${format("%02d", count.index)}-${var.env}-agw" : "aks${format("%02d", count.index)}-${var.env}-agw"
+  name                = "${local.resource_prefix}aks${format("%02d", count.index)}-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
   tags                = var.common_tags

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_application_gateway" "ag" {
-  name                = (var.create_new_agw == true) ? "aks${format("%02d", count.index)}-backend-${var.env}-agw" : "aks${format("%02d", count.index)}-${var.env}-agw"
+  name                = (var.resource_prefix != null) ? "${var.resource_prefix}-aks${format("%02d", count.index)}-${var.env}-agw" : "aks${format("%02d", count.index)}-${var.env}-agw"
   resource_group_name = var.vnet_rg
   location            = var.location
   tags                = var.common_tags

--- a/publicip.tf
+++ b/publicip.tf
@@ -1,7 +1,7 @@
 
 resource "azurerm_public_ip" "app_gw" {
   count               = length(var.private_ip_address)
-  name                = (var.create_new_agw == true) ? local.new_pip_name : local.pip_name
+  name                = (var.create_new_agw == true) ? (element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgateway-${var.env}-pip" : "aks-appgateway-${var.env}-pip-${count.index}") : (element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgw-${var.env}-pip" : "aks-appgw-${var.env}-pip-${count.index}")
   location            = var.location
   resource_group_name = var.vnet_rg
   sku                 = "Standard"

--- a/publicip.tf
+++ b/publicip.tf
@@ -1,7 +1,7 @@
 
 resource "azurerm_public_ip" "app_gw" {
   count               = length(var.private_ip_address)
-  name                = element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgw-${var.env}-pip" : "aks-appgw-${var.env}-pip-${count.index}"
+  name                = (var.create_new_agw == true) ? local.new_pip_name : local.pip_name
   location            = var.location
   resource_group_name = var.vnet_rg
   sku                 = "Standard"

--- a/publicip.tf
+++ b/publicip.tf
@@ -1,7 +1,7 @@
 
 resource "azurerm_public_ip" "app_gw" {
   count               = length(var.private_ip_address)
-  name                = (var.resource_prefix != null) ? (element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "${var.resource_prefix}-aks-appgw-${var.env}-pip" : "${var.resource_prefix}-aks-appgw-${var.env}-pip-${count.index}") : (element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgw-${var.env}-pip" : "aks-appgw-${var.env}-pip-${count.index}")
+  name                = element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "${local.resource_prefix}aks-appgw-${var.env}-pip" : "${local.resource_prefix}aks-appgw-${var.env}-pip-${count.index}"
   location            = var.location
   resource_group_name = var.vnet_rg
   sku                 = "Standard"

--- a/publicip.tf
+++ b/publicip.tf
@@ -1,7 +1,7 @@
 
 resource "azurerm_public_ip" "app_gw" {
   count               = length(var.private_ip_address)
-  name                = (var.create_new_agw == true) ? (element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgateway-${var.env}-pip" : "aks-appgateway-${var.env}-pip-${count.index}") : (element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgw-${var.env}-pip" : "aks-appgw-${var.env}-pip-${count.index}")
+  name                = (var.resource_prefix != null) ? (element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "${var.resource_prefix}-aks-appgw-${var.env}-pip" : "${var.resource_prefix}-aks-appgw-${var.env}-pip-${count.index}") : (element(var.private_ip_address, count.index) == var.private_ip_address[0] ? "aks-appgw-${var.env}-pip" : "aks-appgw-${var.env}-pip-${count.index}")
   location            = var.location
   resource_group_name = var.vnet_rg
   sku                 = "Standard"

--- a/variables.tf
+++ b/variables.tf
@@ -57,5 +57,6 @@ variable "enable_multiple_availability_zones" {
 
 variable "resource_prefix" {
   description = "Optional name prefix for resources"
-  default = ""
+  type        = string
+  default     = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -54,3 +54,8 @@ variable "log_analytics_workspace_id" {}
 variable "enable_multiple_availability_zones" {
   default = false
 }
+
+variable "create_new_agw" {
+  description = "Create resources with new naming convention"
+  default = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -55,7 +55,7 @@ variable "enable_multiple_availability_zones" {
   default = false
 }
 
-variable "create_new_agw" {
-  description = "Create resources with new naming convention"
-  default = false
+variable "resource_prefix" {
+  description = "Optional name prefix for resources"
+  default = ""
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-3187

### Change description ###
To rollout multi-az AGW in CFT, we are adopting a side-by-side deployment approach whereby new AGW with different naming coexists with the live AG prior to switch over.

The module is being updated to support creation of resources with a different naming convention to the existing. Existing resources are left untouched.

Confirmation of no changes to existing appgw resources:
[sds-azure-platform-terraform ](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=215055&view=results)plan
[cft-azure-platform-terraform](https://dev.azure.com/hmcts/CNP/_build/results?buildId=215057&view=results) plan

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
