### PR TITLE
DTSPO-15732 - Allow App gateway to access certs

### DIFF
--- a/identity.tf
+++ b/identity.tf
@@ -14,3 +14,10 @@ resource "azurerm_role_assignment" "identity" {
 
   role_definition_name = "Key Vault Secrets User"
 }
+
+resource "azurerm_role_assignment" "certificates_access" {
+  principal_id = azurerm_user_assigned_identity.identity.principal_id
+  scope        = data.azurerm_key_vault.main.id
+
+  role_definition_name = "Key Vault Certificates Officer"
+}


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15732

### Change description ###

Raised in the plat ops help, App Gateway Managed Identity did not have access to ACME certificates hence it was failing to auto renew

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

